### PR TITLE
Also show UTF-8 encoding

### DIFF
--- a/uni
+++ b/uni
@@ -59,7 +59,15 @@ sub print_chars {
 
     my $chr  = ord($c);
     my $name = charnames::viacode($chr);
-    printf "%s- U+%05X - %s\n", $p, $chr, $name;
+    
+    my $utf8_rep = '';
+    {
+      use bytes;
+      my $format = "0x%02X " x length($c);
+      chop $format;
+      $utf8_rep = sprintf $format, map { ord($_) } split( '', $c );
+    }
+    printf "%s- U+%05X (%s) - %s\n", $p, $chr, $utf8_rep, $name;
   }
 }
 


### PR DESCRIPTION
I often need to see the (multi-byte) UTF-8 encoding of characters.
I didn´t feel the need to add a switch for activating the extra output since it´s really not that much more text that´s printed.
