### PR TITLE
Fixed problem with github repo's not owned by the user and made it more generic

### DIFF
--- a/code-review
+++ b/code-review
@@ -157,13 +157,14 @@ sub do_review {
           || ($project ? "did review of $project"
                        : "rebuilt code-review state file");
 
+  my $gh_user = $opt->githubid;
   open my $mkdn, '>', 'code-review.mkdn' or die "can't open mkdn: $!";
 
   print {$mkdn} <<END_HEADER;
 This file is computer-generated for humans to read.  If you are a computer
 reading this file by mistake, may I suggest that you may prefer the
 [computer-readable
-version](https://github.com/rjbs/misc/blob/master/code-review.yaml) instead.
+version](https://github.com/$gh_user/misc/blob/master/code-review.yaml) instead.
 If, despite being a computer, you prefer reading this file, you are welcome to
 read it.  Be advised, though, that its format may change in the future.
 
@@ -179,7 +180,7 @@ items in this list from top to bottom.  Once I've worked on an item, it moves
 to the bottom of the list.
 
 You can read [the program that generates this
-file](https://github.com/rjbs/misc/blob/master/code-review) if you like.
+file](https://github.com/$gh_user/misc/blob/master/code-review) if you like.
 
 | PROJECT NAME                            | LAST REVIEW
 | --------------------------------------- | -------------
@@ -250,6 +251,7 @@ sub cpan_notes {
   }
 
   my $gh_repo_name = $name;
+  my $gh_user = $opt->githubid;
 
   my $repo = $release->metadata->{resources}{repository}{url};
   if (! $repo) {
@@ -259,7 +261,7 @@ sub cpan_notes {
   } elsif ($repo =~ /\Q$name/i && $repo !~ /\Q$name/) {
     $gh_repo_name = lc $name;
     push @notes, "GitHub repo is not capitalized correctly";
-  } elsif ($repo =~ m{github\.com/rjbs/(.+?)(?:\.git)}) {
+  } elsif ($repo =~ m{github\.com/\Q$gh_user\E/(.+?)(?:\.git)}) {
     $gh_repo_name = $1;
   } elsif ($repo =~ m{github\.com/(.+?)(?:\.git)}) {
     $gh_repo_name = $1;

--- a/code-review
+++ b/code-review
@@ -261,6 +261,8 @@ sub cpan_notes {
     push @notes, "GitHub repo is not capitalized correctly";
   } elsif ($repo =~ m{github\.com/rjbs/(.+?)(?:\.git)}) {
     $gh_repo_name = $1;
+  } elsif ($repo =~ m{github\.com/(.+?)(?:\.git)}) {
+    $gh_repo_name = $1;
   }
 
   push @notes, gh_notes($gh_repo_name);
@@ -305,7 +307,10 @@ sub gh_notes {
   my $res = $gh_ua->get("https://api.github.com/repos/$gh_user/$gh_repo_name");
 
   unless ($res->is_success) {
-    return ("Couldn't get repo data for $gh_user/$gh_repo_name from GitHub");
+    $res = $gh_ua->get("https://api.github.com/repos/$gh_repo_name");
+    unless ($res->is_success) {
+      return ("Couldn't get repo data for $gh_user/$gh_repo_name from GitHub");
+    }
   }
 
   my $repo = JSON->new->decode($res->decoded_content);


### PR DESCRIPTION
I don't know whether you want these changes or not, but I made them for myself and figured they might be useful.

I got rid of the remaining hard coded references to your username and made it cope with you having released distro's where you don't own the github repo.